### PR TITLE
patch libtool/package.py

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -66,4 +66,4 @@ class Libtool(AutotoolsPackage):
         symlink(join_path(self.prefix.bin, 'libtoolize'),
                 join_path(self.prefix.bin, 'glibtoolize'))
         symlink(join_path(self.prefix.bin, 'libtoolize'),
-                join_path(self.prefix.bin, 'glibtoolize'))
+                join_path(self.prefix.bin, 'glibtool'))


### PR DESCRIPTION
both lines are exactly the same, generating this problem

==> Error: OSError: [Errno 17] File exists
OSError: OSError: [Errno 17] File exists
/opt/spack/var/spack/repos/builtin/packages/libtool/package.py:69, in post_install:
     8             symlink(join_path(self.prefix.bin, 'libtoolize'),
     9                     join_path(self.prefix.bin, 'glibtoolize'))
     10            symlink(join_path(self.prefix.bin, 'libtoolize'),
  >> 11                    join_path(self.prefix.bin, 'glibtoolize'))